### PR TITLE
Fixed display of Pet Hydra in Tavern (Tier 6)

### DIFF
--- a/website/views/options/social/tavern.jade
+++ b/website/views/options/social/tavern.jade
@@ -116,7 +116,7 @@
                 a.label.label-contributor-6(ng-click='toggleUserTier($event)')=env.t('tier') + ' 6 (' + env.t('champion') + ')'
                 div
                   p
-                    div(class='Pet-Dragon-Hydra pull-left')
+                    span.shop-sprite.item-img(class='Pet-Dragon-Hydra')
                     !=env.t('championSixth')
             tr
               td


### PR DESCRIPTION
In the Tier 6 contributor description, the Pet Hydra wasn't displaying. Changed `div` tag to `span` to fix the issue.