### PR TITLE
Refactor chat related things into own service

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -45,6 +45,7 @@ module.exports = function(config) {
       "common/script/public/userServices.js",
       "common/script/public/directives.js",
       "website/public/js/services/groupServices.js",
+      "website/public/js/services/chatServices.js",
       "website/public/js/services/memberServices.js",
       "website/public/js/services/guideServices.js",
       "website/public/js/services/challengeServices.js",

--- a/test/spec/chatServicesSpec.js
+++ b/test/spec/chatServicesSpec.js
@@ -1,0 +1,90 @@
+'use strict';
+
+describe('Chat Service', function() {
+  var $httpBackend, $http, chat, user;
+
+  beforeEach(function() {
+    module(function($provide) {
+      var usr = specHelper.newUser();
+      $provide.value('User', {user:usr});
+    });
+
+    inject(function(_$httpBackend_, Chat, User) {
+      $httpBackend = _$httpBackend_;
+      chat = Chat;
+      user = User;
+    });
+  });
+
+  describe('utils', function() {
+    it('calls chat post endpoint', function() {
+      var payload = {
+        gid: 'habitrpg',
+        message: 'Chat',
+        previousMsg: 'previous-msg-id'
+      }
+
+      $httpBackend.expectPOST('/api/v2/groups/habitrpg/chat?message=Chat&previousMsg=previous-msg-id').respond();
+      chat.utils.postChat(payload, undefined);
+      $httpBackend.flush();
+    });
+
+    it('calls chat like endpoint', function() {
+      var payload = {
+        gid: 'habitrpg',
+        messageId: 'msg-id'
+      }
+
+      $httpBackend.expectPOST('/api/v2/groups/habitrpg/chat/msg-id/like').respond();
+      chat.utils.like(payload, undefined);
+      $httpBackend.flush();
+    });
+
+    it('calls delete chat endpoint', function() {
+      var payload = {
+        gid: 'habitrpg',
+        messageId: 'msg-id'
+      }
+
+      $httpBackend.expectDELETE('/api/v2/groups/habitrpg/chat/msg-id').respond();
+      chat.utils.deleteChatMessage(payload, undefined);
+      $httpBackend.flush();
+    });
+
+    it('calls flag chat endpoint', function() {
+      var payload = {
+        gid: 'habitrpg',
+        messageId: 'msg-id'
+      }
+
+      $httpBackend.expectPOST('/api/v2/groups/habitrpg/chat/msg-id/flag').respond();
+      chat.utils.flagChatMessage(payload, undefined);
+      $httpBackend.flush();
+    });
+
+    it('calls clear flags endpoint', function() {
+      var payload = {
+        gid: 'habitrpg',
+        messageId: 'msg-id'
+      }
+
+      $httpBackend.expectPOST('/api/v2/groups/habitrpg/chat/msg-id/clearflags').respond();
+      chat.utils.clearFlagCount(payload, undefined);
+      $httpBackend.flush();
+    });
+  });
+
+  describe('seenMessage(gid)', function() {
+    it('calls chat seen endpoint', function() {
+      $httpBackend.expectPOST('/api/v2/groups/habitrpg/chat/seen').respond();
+      chat.seenMessage('habitrpg');
+      $httpBackend.flush();
+    });
+
+    it('removes newMessages for a specific guild from user object', function() {
+      user.user.newMessages = {habitrpg: "foo"};
+      chat.seenMessage('habitrpg');
+      expect(user.user.newMessages.habitrpg).to.not.exist;
+    });
+  });
+});

--- a/test/spec/chatServicesSpec.js
+++ b/test/spec/chatServicesSpec.js
@@ -17,7 +17,7 @@ describe('Chat Service', function() {
   });
 
   describe('utils', function() {
-    it('calls chat post endpoint', function() {
+    it('calls post chat endpoint', function() {
       var payload = {
         gid: 'habitrpg',
         message: 'Chat',
@@ -29,7 +29,7 @@ describe('Chat Service', function() {
       $httpBackend.flush();
     });
 
-    it('calls chat like endpoint', function() {
+    it('calls like chat endpoint', function() {
       var payload = {
         gid: 'habitrpg',
         messageId: 'msg-id'

--- a/website/public/js/app.js
+++ b/website/public/js/app.js
@@ -120,11 +120,11 @@ window.habitrpg = angular.module('habitrpg',
         .state('options.social.guilds.detail', {
           url: '/:gid',
           templateUrl: 'partials/options.social.guilds.detail.html',
-          controller: ['$scope', 'Groups', '$stateParams',
-          function($scope, Groups, $stateParams){
+          controller: ['$scope', 'Groups', 'Chat', '$stateParams',
+          function($scope, Groups, Chat, $stateParams){
             Groups.Group.get({gid:$stateParams.gid}, function(group){
               $scope.group = group;
-              Groups.seenMessage(group._id);
+              Chat.seenMessage(group._id);
             });
           }]
         })

--- a/website/public/js/services/chatServices.js
+++ b/website/public/js/services/chatServices.js
@@ -1,8 +1,8 @@
 'use strict';
 
 angular.module('habitrpg').factory('Chat',
-['$resource', '$q', '$http', 'ApiUrl', 'User',
-function($resource, $q, $http, ApiUrl, User) {
+['$resource', '$http', 'ApiUrl', 'User',
+function($resource, $http, ApiUrl, User) {
   var utils = $resource(ApiUrl.get() + '/api/v2/groups/:gid',
     {gid:'@_id', messageId: '@_messageId'},
     {

--- a/website/public/js/services/chatServices.js
+++ b/website/public/js/services/chatServices.js
@@ -1,0 +1,28 @@
+'use strict';
+
+angular.module('habitrpg').factory('Chat',
+['$resource', '$q', '$http', 'ApiUrl', 'User',
+function($resource, $q, $http, ApiUrl, User) {
+  var utils = $resource(ApiUrl.get() + '/api/v2/groups/:gid',
+    {gid:'@_id', messageId: '@_messageId'},
+    {
+      postChat: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/chat'},
+      like: {method: 'POST', isArray: true, url: ApiUrl.get() + '/api/v2/groups/:gid/chat/:messageId/like'},
+      deleteChatMessage: {method: "DELETE", url: ApiUrl.get() + '/api/v2/groups/:gid/chat/:messageId'},
+      flagChatMessage: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/chat/:messageId/flag'},
+      clearFlagCount: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/chat/:messageId/clearflags'},
+    });
+
+  var chatService = {
+    seenMessage: seenMessage,
+    utils: utils
+  };
+
+  return chatService;
+
+  function seenMessage(gid) {
+    // On enter, set chat message to "seen"
+    $http.post(ApiUrl.get() + '/api/v2/groups/'+gid+'/chat/seen');
+    if (User.user.newMessages) delete User.user.newMessages[gid];
+  }
+}])

--- a/website/public/js/services/groupServices.js
+++ b/website/public/js/services/groupServices.js
@@ -23,10 +23,6 @@ function(ApiUrl, $resource, $q, $http, User, Challenges) {
         }
       },
 
-      postChat: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/chat'},
-      deleteChatMessage: {method: "DELETE", url: ApiUrl.get() + '/api/v2/groups/:gid/chat/:messageId'},
-      flagChatMessage: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/chat/:messageId/flag'},
-      clearFlagCount: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/chat/:messageId/clearflags'},
       join: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/join'},
       leave: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/leave'},
       invite: {method: "POST", url: ApiUrl.get() + '/api/v2/groups/:gid/invite'},
@@ -66,12 +62,6 @@ function(ApiUrl, $resource, $q, $http, User, Challenges) {
       return data.tavern;
     },
 
-    // On enter, set chat message to "seen"
-    seenMessage: function(gid){
-      $http.post(ApiUrl.get() + '/api/v2/groups/'+gid+'/chat/seen');
-      if (User.user.newMessages) delete User.user.newMessages[gid];
-    },
-
     questAccept: function(party){
       party.$questAccept()
         .then(syncUser, logError);
@@ -99,19 +89,3 @@ function(ApiUrl, $resource, $q, $http, User, Challenges) {
     Group: Group
   }
 }])
-/**
- * TODO Get this working. Make ChatService it's own ngResource, so we can update chat without having to sync the whole
- * group object (expensive). Also so we can add chat-specific routes
- */
-//    .factory('Chat', ['API_URL', '$resource',
-//      function(API_URL, $resource) {
-//        var Chat = $resource(API_URL + '/api/v2/groups/:gid/chat/:mid',
-//          //{gid:'@_id', mid: '@_messageId'},
-//          {
-//            like: {method: 'POST', url: API_URL + '/api/v2/groups/:gid/chat/:mid'}
-//            //postChat: {method: "POST", url: API_URL + '/api/v2/groups/:gid/chat'},
-//            //deleteChatMessage: {method: "DELETE", url: API_URL + '/api/v2/groups/:gid/chat/:messageId'},
-//          });
-//        return {Chat:Chat};
-//      }
-//    ]);

--- a/website/public/manifest.json
+++ b/website/public/manifest.json
@@ -43,6 +43,7 @@
             "common/script/public/userServices.js",
             "common/script/public/directives.js",
             "js/services/groupServices.js",
+            "js/services/chatServices.js",
             "js/services/memberServices.js",
             "js/services/guideServices.js",
             "js/services/challengeServices.js",

--- a/website/src/controllers/groups.js
+++ b/website/src/controllers/groups.js
@@ -422,6 +422,9 @@ api.likeChatMessage = function(req, res, next) {
   group.markModified('chat');
   group.save(function(err,_saved){
     if (err) return next(err);
+    // @TODO: We're sending back the entire array of chats back
+    // Should we just send back the object of the single chat message?
+    // If not, should we update the group chat when a chat is liked?
     return res.send(_saved.chat);
   })
 }


### PR DESCRIPTION
No change has been made to the functionality (yet), this is just a refactor. 

It doesn't fulfill the any of the checklists on the main PR, but is a good step toward making some refinements to how chats are handles on the group pages.

I'm of the opinion that a "Fetch recent messages" button should do exactly as it says, and fetch recent messages, not the entire group. 